### PR TITLE
Refactor network caching and add stats endpoint

### DIFF
--- a/src/server/networks/index.ts
+++ b/src/server/networks/index.ts
@@ -3,34 +3,14 @@ import { getDB } from '../../db/index'
 import _ from 'lodash'
 import { tableNames } from '@/db/tables'
 import { Network } from 'knex/types/tables.js'
+import { cacheResult } from '@/utils'
 
 export const router = Router()
 
-let cached: null | {
-  timestamp: number
-  result: Promise<string[]>
-} = null
-const hour1 = 1000 * 60 * 60
-const getNetworks = _.wrap(
-  async () => {
-    const networks = await getDB().select<Network[]>(['chainId']).from(tableNames.network)
-    return networks.map((n) => `${n.chainId}`)
-  },
-  async (fn) => {
-    if (cached) {
-      const { timestamp, result } = cached
-      if (timestamp > Date.now() - hour1) {
-        return result
-      }
-    }
-    const networks = fn()
-    cached = {
-      timestamp: Date.now(),
-      result: networks,
-    }
-    return networks
-  },
-)
+const getNetworks = cacheResult<string[]>(async () => {
+  const networks = await getDB().select<Network[]>(['chainId']).from(tableNames.network)
+  return networks.map((n) => `${n.chainId}`)
+})
 
 router.get('/', async (_req, res) => {
   const networks = await getNetworks()

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 import { router as imageRouter } from './image'
 import { router as listRouter } from './list'
 import { router as networksRouter } from './networks'
+import { router as statsRouter } from './stats'
 
 export const router = Router()
 
@@ -16,3 +17,6 @@ router.use('/image', imageRouter)
 router.use('/list', listRouter)
 
 router.use('/networks', networksRouter)
+
+// gib.show/stats
+router.use('/stats', statsRouter)

--- a/src/server/stats/index.ts
+++ b/src/server/stats/index.ts
@@ -1,0 +1,34 @@
+import { getDB } from '@/db'
+import { tableNames } from '@/db/tables'
+import { cacheResult } from '@/utils'
+import { Router } from 'express'
+import _ from 'lodash'
+
+const db = getDB()
+
+export const router = Router()
+
+type Result = {
+  chainId: string
+  count: number
+}
+
+const getStats = cacheResult<Result[]>(async () => {
+  const counts = await db
+    .select([
+      'network.chainId', //
+      db.raw('count(distinct(network.network_id, lower(token.token_id))) as count'),
+    ])
+    .from(tableNames.network)
+    .innerJoin(tableNames.token, 'network.network_id', 'token.network_id')
+    .innerJoin(tableNames.listToken, 'token.tokenId', 'listToken.tokenId')
+    .whereNotNull('listToken.imageHash')
+    .groupBy('network.chainId')
+    .orderBy('count', 'desc')
+  return counts
+})
+
+router.get('/', async (_req, res) => {
+  const counts = await getStats()
+  res.send(counts)
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -260,3 +260,24 @@ export const toKeccakBytes = (s: string) => viem.keccak256(viem.toBytes(s)).slic
 
 export const directUri = ({ imageHash, ext }: { imageHash: string; ext: string }) =>
   imageHash && ext ? `${config.rootURI}/image/direct/${imageHash}${ext}` : undefined
+
+export const cacheResult = <T>(worker: () => Promise<T>, duration = 1000 * 60 * 60) => {
+  let cached: null | {
+    timestamp: number
+    result: Promise<T>
+  } = null
+
+  return _.wrap(worker, (fn) => {
+    if (cached) {
+      const { timestamp, result } = cached
+      if (timestamp > Date.now() - duration) {
+        return result
+      }
+    }
+    cached = {
+      timestamp: Date.now(),
+      result: fn(),
+    }
+    return cached.result
+  })
+}


### PR DESCRIPTION
- Implement cacheResult utility function for reusable caching
- Simplify getNetworks function using cacheResult
- Add new stats router and endpoint
- Create getStats function to fetch token counts by network