### PR TITLE
refactor: centralize error handling with nextOnError wrapper

### DIFF
--- a/src/server/image/index.ts
+++ b/src/server/image/index.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express'
 import * as handlers from './handlers'
+import { nextOnError } from '../utils'
 
 export const router = Router() as Router
 
-router.use('/direct/:imageHash', handlers.getImageByHash)
-router.use('/fallback/:order/:chainId/:address', handlers.getImageAndFallback)
-router.use('/:order/:chainId/:address', handlers.getImage(true))
-router.use('/:chainId/:address', handlers.getImage(false))
+router.use('/direct/:imageHash', nextOnError(handlers.getImageByHash))
+router.use('/fallback/:order/:chainId/:address', nextOnError(handlers.getImageAndFallback))
+router.use('/:order/:chainId/:address', nextOnError(handlers.getImage(true)))
+router.use('/:chainId/:address', nextOnError(handlers.getImage(false)))
 // best guess
-router.use('/:chainId', handlers.bestGuessNetworkImageFromOnOnChainInfo)
-router.use('/', handlers.tryMultiple)
+router.use('/:chainId', nextOnError(handlers.bestGuessNetworkImageFromOnOnChainInfo))
+router.use('/', nextOnError(handlers.tryMultiple))

--- a/src/server/list/index.ts
+++ b/src/server/list/index.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express'
 import * as handlers from './handlers'
+import { nextOnError } from '../utils'
 
 export const router = Router() as Router
 
-router.get('/merged/:order', handlers.merged)
-router.get('/:providerKey/:listKey/:version', handlers.versioned)
-router.get('/:providerKey/:listKey?', handlers.providerKeyed)
-router.get('/bridge/:providerKey/:listKey?', handlers.providerKeyed)
-router.get('/', handlers.all)
+router.get('/merged/:order', nextOnError(handlers.merged))
+router.get('/:providerKey/:listKey/:version', nextOnError(handlers.versioned))
+router.get('/:providerKey/:listKey?', nextOnError(handlers.providerKeyed))
+router.get('/bridge/:providerKey/:listKey?', nextOnError(handlers.providerKeyed))
+router.get('/', nextOnError(handlers.all))

--- a/src/server/networks/index.ts
+++ b/src/server/networks/index.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import { tableNames } from '@/db/tables'
 import { Network } from 'knex/types/tables.js'
 import { cacheResult } from '@/utils'
-
+import { nextOnError } from '../utils'
 export const router = Router() as Router
 
 const getNetworks = cacheResult<string[]>(async () => {
@@ -12,7 +12,7 @@ const getNetworks = cacheResult<string[]>(async () => {
   return networks.map((n) => `${n.chainId}`)
 })
 
-router.get('/', async (_req, res) => {
+router.get('/', nextOnError(async (_req, res) => {
   const networks = await getNetworks()
   res.json(networks)
-})
+}))

--- a/src/server/stats/index.ts
+++ b/src/server/stats/index.ts
@@ -3,6 +3,7 @@ import { tableNames } from '@/db/tables'
 import { cacheResult } from '@/utils'
 import { Router } from 'express'
 import _ from 'lodash'
+import { nextOnError } from '../utils'
 
 const db = getDB()
 
@@ -28,7 +29,10 @@ const getStats = cacheResult<Result[]>(async () => {
   return counts
 })
 
-router.get('/', async (_req, res) => {
-  const counts = await getStats()
-  res.send(counts)
-})
+router.get(
+  '/',
+  nextOnError(async (_req, res) => {
+    const counts = await getStats()
+    res.send(counts)
+  }),
+)

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,7 +1,9 @@
 import type { NextFunction, RequestHandler, Request, Response } from 'express'
 
-export const nextOnError = (handler: RequestHandler) => {
-  return async (req: Request, res: Response, next: NextFunction) => {
+export const nextOnError = <Params, Body, ResBody, ReqQuery>(
+  handler: RequestHandler<Params, Body, ResBody, ReqQuery>,
+) => {
+  return async (req: Request<Params, Body, ResBody, ReqQuery>, res: Response, next: NextFunction) => {
     try {
       return await handler(req, res, next)
     } catch (err) {


### PR DESCRIPTION
- Move nextOnError function to utils.ts
- Apply nextOnError wrapper to all route handlers
- Remove try-catch blocks from individual handlers
- Update type definition of nextOnError for better type inference

BREAKING CHANGE: Error handling is now centralized, which may affect how errors are processed in the application