### PR TITLE
fix(ui): resolve undefined API base URL in production builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN yarn install --immutable
 # Now copy source and build
 COPY tsconfig.json ./
 COPY packages packages
+
+ARG PUBLIC_BASE_URL
+ENV PUBLIC_BASE_URL=$PUBLIC_BASE_URL
 RUN yarn run build
 
 # Prune dev dependencies

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     replace({
       preventAssignment: true,
       values: {
-        'process.env.PUBLIC_BASE_URL': JSON.stringify(process.env.PUBLIC_BASE_URL),
+        'process.env.PUBLIC_BASE_URL': JSON.stringify(process.env.PUBLIC_BASE_URL ?? ''),
         'process.env.PUBLIC_NODE_ENV': JSON.stringify(process.env.PUBLIC_NODE_ENV),
         'process.env.PUBLIC_VERSION': JSON.stringify([pkg.version, githash, new Date().toISOString()].join('_')),
       },


### PR DESCRIPTION
PUBLIC_BASE_URL was only set in the Docker production stage but yarn build runs in the builder stage. Pass it as a build arg. Also fallback to empty string so relative paths work when unset.