### PR TITLE
fix(server): restore row_to_json bridge columns lost in Drizzle migra…

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -37,8 +37,7 @@ import _ from 'lodash'
 import promiseLimit from 'promise-limit'
 import * as args from '../args'
 import { getDrizzle, type DrizzleTx } from './drizzle'
-import { eq, and, or, lt, gte, desc, ilike, inArray, sql as dsql, type SQL } from 'drizzle-orm'
-import { alias } from 'drizzle-orm/pg-core'
+import { eq, and, lt, gte, desc, ilike, inArray, sql as dsql, type SQL } from 'drizzle-orm'
 import * as s from './schema'
 
 export const ids = {
@@ -1043,35 +1042,102 @@ export const getLists = async (providerKey: string, listKey: string) => {
  * `headerListTokenId` / `headerImageHash` must access them from the
  * `header_link` portion of the flattened row.
  */
-export const addHeaderUriExtension = <T extends ReturnType<typeof getTokensUnderListId>>(qb: T) => {
-  return qb.fullJoin(s.headerLink, eq(s.headerLink.listTokenId, s.listToken.listTokenId))
+/**
+ * Recursively convert an object's keys from snake_case to camelCase.
+ * Used to post-process row_to_json() results, which return DB column names.
+ */
+const camelCaseKeys = (obj: Record<string, unknown> | null): Record<string, unknown> | null => {
+  if (!obj) return null
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [_.camelCase(k), v]))
 }
 
-const networkA = alias(s.network, 'network_a')
-const networkB = alias(s.network, 'network_b')
-const nativeToken = alias(s.token, 'native_token')
-const bridgedToken = alias(s.token, 'bridged_token')
-
 /**
- * Add bridge extension joins. Like `addHeaderUriExtension`, Drizzle $dynamic()
- * cannot add new select columns after initial select. The row_to_json columns
- * are handled via raw SQL in callers that need the full bridge info.
+ * Fetch tokens under a list with bridge and/or header extensions via raw SQL.
  *
- * For the list/utils.ts `respondWithList` path, we add the joins so the data
- * is accessible in the flattened result. The `row_to_json` aggregation is done
- * at the application layer in `normalizeTokens`.
+ * Drizzle's $dynamic() can add JOINs but NOT SELECT columns. The old Knex code
+ * used row_to_json() to embed joined tables as nested JSON objects, plus a global
+ * postProcessResponse to camelCase all keys. This function reproduces that behavior
+ * using raw SQL (same pattern as applyOrder).
  */
-export const addBridgeExtensions = <T extends ReturnType<typeof getTokensUnderListId>>(qb: T) => {
-  return qb
-    .fullJoin(
-      s.bridgeLink,
-      or(eq(s.bridgeLink.nativeTokenId, s.token.tokenId), eq(s.bridgeLink.bridgedTokenId, s.token.tokenId)),
-    )
-    .innerJoin(s.bridge, eq(s.bridge.bridgeId, s.bridgeLink.bridgeId))
-    .innerJoin(networkA, eq(networkA.networkId, s.bridge.homeNetworkId))
-    .innerJoin(networkB, eq(networkB.networkId, s.bridge.foreignNetworkId))
-    .innerJoin(nativeToken, eq(nativeToken.tokenId, s.bridgeLink.nativeTokenId))
-    .innerJoin(bridgedToken, eq(bridgedToken.tokenId, s.bridgeLink.bridgedTokenId))
+export const getTokensWithExtensions = async (
+  listId: string,
+  { bridgeInfo = false, headerUri = false }: { bridgeInfo?: boolean; headerUri?: boolean } = {},
+) => {
+  const db = getDrizzle()
+  const result = await db.execute<Record<string, unknown>>(dsql`
+    SELECT
+      "network"."chain_id" AS "chainId",
+      "token"."provided_id" AS "providedId",
+      "token"."decimals",
+      "token"."symbol",
+      "token"."name",
+      "token"."token_id" AS "tokenId",
+      "image"."image_hash" AS "imageHash",
+      "image"."ext",
+      "image"."mode",
+      "image"."uri",
+      "provider"."key" AS "providerKey",
+      "list"."key" AS "listKey"
+      ${
+        bridgeInfo
+          ? dsql`
+        , row_to_json("bridge".*) AS "bridge"
+        , row_to_json("bridge_link".*) AS "bridgeLink"
+        , row_to_json("network_a".*) AS "networkA"
+        , row_to_json("network_b".*) AS "networkB"
+        , row_to_json("native_token".*) AS "nativeToken"
+        , row_to_json("bridged_token".*) AS "bridgedToken"
+      `
+          : dsql``
+      }
+      ${
+        headerUri
+          ? dsql`
+        , "header_link"."image_hash" AS "headerImageHash"
+      `
+          : dsql``
+      }
+    FROM "list_token"
+    FULL JOIN "image" ON "image"."image_hash" = "list_token"."image_hash"
+    INNER JOIN "token" ON "token"."token_id" = "list_token"."token_id"
+    INNER JOIN "network" ON "network"."network_id" = "token"."network_id"
+    INNER JOIN "list" ON "list"."list_id" = "list_token"."list_id"
+    INNER JOIN "provider" ON "provider"."provider_id" = "list"."provider_id"
+    ${
+      bridgeInfo
+        ? dsql`
+      FULL JOIN "bridge_link" ON (
+        "bridge_link"."native_token_id" = "token"."token_id"
+        OR "bridge_link"."bridged_token_id" = "token"."token_id"
+      )
+      INNER JOIN "bridge" ON "bridge"."bridge_id" = "bridge_link"."bridge_id"
+      INNER JOIN "network" AS "network_a" ON "network_a"."network_id" = "bridge"."home_network_id"
+      INNER JOIN "network" AS "network_b" ON "network_b"."network_id" = "bridge"."foreign_network_id"
+      INNER JOIN "token" AS "native_token" ON "native_token"."token_id" = "bridge_link"."native_token_id"
+      INNER JOIN "token" AS "bridged_token" ON "bridged_token"."token_id" = "bridge_link"."bridged_token_id"
+    `
+        : dsql``
+    }
+    ${
+      headerUri
+        ? dsql`
+      FULL JOIN "header_link" ON "header_link"."list_token_id" = "list_token"."list_token_id"
+    `
+        : dsql``
+    }
+    WHERE "list_token"."list_id" = ${listId}
+    ORDER BY "list_token"."list_token_order_id" ASC
+  `)
+  if (!bridgeInfo) return result.rows
+  return result.rows.map((row) => ({
+    ...row,
+    bridge: camelCaseKeys(row.bridge as Record<string, unknown> | null),
+    bridgeLink: camelCaseKeys(row.bridgeLink as Record<string, unknown> | null),
+    networkA: camelCaseKeys(row.networkA as Record<string, unknown> | null),
+    networkB: camelCaseKeys(row.networkB as Record<string, unknown> | null),
+    nativeToken: camelCaseKeys(row.nativeToken as Record<string, unknown> | null),
+    bridgedToken: camelCaseKeys(row.bridgedToken as Record<string, unknown> | null),
+  }))
 }
 
 export const getListOrderId = async (orderParam: string) => {

--- a/packages/server/src/server/list/utils.test.ts
+++ b/packages/server/src/server/list/utils.test.ts
@@ -1,16 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockGetTokensUnderListId = vi.fn()
-const mockAddBridgeExtensions = vi.fn()
-const mockAddHeaderUriExtension = vi.fn()
+const mockGetTokensWithExtensions = vi.fn()
 
 vi.mock('../../db/tables', () => ({
   imageMode: { SAVE: 'save', LINK: 'link' },
 }))
 vi.mock('../../db', () => ({
   getTokensUnderListId: (...args: unknown[]) => mockGetTokensUnderListId(...args),
-  addBridgeExtensions: (...args: unknown[]) => mockAddBridgeExtensions(...args),
-  addHeaderUriExtension: (...args: unknown[]) => mockAddHeaderUriExtension(...args),
+  getTokensWithExtensions: (...args: unknown[]) => mockGetTokensWithExtensions(...args),
 }))
 vi.mock('../../db/drizzle', () => ({ getDrizzle: vi.fn() }))
 vi.mock('../../db/schema', () => ({
@@ -587,34 +585,34 @@ describe('respondWithList', () => {
     expect(body.version).toEqual({ major: 0, minor: 0, patch: 0 })
   })
 
-  it('calls addBridgeExtensions when bridgeInfo extension is requested', async () => {
-    const query = createMockQuery([])
-    mockAddBridgeExtensions.mockReturnValue(query)
+  it('uses getTokensWithExtensions when bridgeInfo extension is requested', async () => {
+    mockGetTokensWithExtensions.mockResolvedValue([])
     const res = createMockResponse()
 
     await respondWithList(res as any, baseList, [], new Set(['bridgeInfo']))
 
-    expect(mockAddBridgeExtensions).toHaveBeenCalled()
+    expect(mockGetTokensWithExtensions).toHaveBeenCalledWith('list-1', { bridgeInfo: true, headerUri: false })
+    expect(mockGetTokensUnderListId).not.toHaveBeenCalled()
   })
 
-  it('calls addHeaderUriExtension when headerUri extension is requested', async () => {
-    const query = createMockQuery([])
-    mockAddHeaderUriExtension.mockReturnValue(query)
+  it('uses getTokensWithExtensions when headerUri extension is requested', async () => {
+    mockGetTokensWithExtensions.mockResolvedValue([])
     const res = createMockResponse()
 
     await respondWithList(res as any, baseList, [], new Set(['headerUri']))
 
-    expect(mockAddHeaderUriExtension).toHaveBeenCalled()
+    expect(mockGetTokensWithExtensions).toHaveBeenCalledWith('list-1', { bridgeInfo: false, headerUri: true })
+    expect(mockGetTokensUnderListId).not.toHaveBeenCalled()
   })
 
-  it('does not call bridge/header extensions when not requested', async () => {
+  it('uses getTokensUnderListId when no extensions are requested', async () => {
     createMockQuery([])
     const res = createMockResponse()
 
     await respondWithList(res as any, baseList, [], new Set())
 
-    expect(mockAddBridgeExtensions).not.toHaveBeenCalled()
-    expect(mockAddHeaderUriExtension).not.toHaveBeenCalled()
+    expect(mockGetTokensUnderListId).toHaveBeenCalled()
+    expect(mockGetTokensWithExtensions).not.toHaveBeenCalled()
   })
 
   it('passes filters through to normalizeTokens', async () => {

--- a/packages/server/src/server/list/utils.ts
+++ b/packages/server/src/server/list/utils.ts
@@ -36,15 +36,15 @@ export const respondWithList = async (
   filters: Filter<Network & Token>[] = [],
   extensions: Set<string>,
 ) => {
-  let q = db.getTokensUnderListId().where(eq(s.listToken.listId, list.listId))
-  if (extensions.has('bridgeInfo')) {
-    q = db.addBridgeExtensions(q) as unknown as typeof q
-  }
-  if (extensions.has('headerUri')) {
-    q = db.addHeaderUriExtension(q) as unknown as typeof q
-  }
-  const tokens = await q.orderBy(asc(s.listToken.listTokenOrderId))
-  // could possibly be turned into a query
+  const hasBridge = extensions.has('bridgeInfo')
+  const hasHeader = extensions.has('headerUri')
+  const tokens =
+    hasBridge || hasHeader
+      ? await db.getTokensWithExtensions(list.listId, { bridgeInfo: hasBridge, headerUri: hasHeader })
+      : await db
+          .getTokensUnderListId()
+          .where(eq(s.listToken.listId, list.listId))
+          .orderBy(asc(s.listToken.listTokenOrderId))
   const tkns = normalizeTokens(tokens as unknown as TokenInfo[], filters, extensions)
   res.set('cache-control', `public, max-age=${config.cacheSeconds}`)
   res.json({
@@ -99,7 +99,7 @@ export const normalizeTokens = (
             tkns,
             (ext, tkn) => {
               if (bridgeInfoExtension) {
-                if (tkn.bridge.bridgeId && viem.isAddress(tkn.providedId)) {
+                if (tkn.bridge?.bridgeId && viem.isAddress(tkn.providedId)) {
                   everAddedExtension = true
                   const networkNotSelf = +tkn.chainId === +tkn.networkA.chainId ? tkn.networkB : tkn.networkA
                   const tokenNotSelf =


### PR DESCRIPTION
…tion

The Knex→Drizzle migration (Phase 4) converted addBridgeExtensions to use $dynamic() JOINs, but Drizzle's $dynamic() cannot add SELECT columns. The old Knex code used row_to_json() + postProcessResponse camelCase conversion to embed bridge/network/token data as nested JSON objects.

Replace broken $dynamic() extension pattern with raw SQL query (getTokensWithExtensions) that includes row_to_json() columns and camelCaseKeys post-processing — matching original Knex output.