### PR TITLE
Release: dexscreener metadata collection

### DIFF
--- a/packages/dexscreener/src/index.ts
+++ b/packages/dexscreener/src/index.ts
@@ -1,4 +1,4 @@
-import { fetch, limitByTime } from '@gibs/utils/fetch'
+import { fetch, limitByTime, retry } from '@gibs/utils/fetch'
 import { type Chain, defineChain } from 'viem'
 import * as chains from 'viem/chains'
 import type * as dexscreenerSDK from 'dexscreener-sdk'
@@ -57,9 +57,29 @@ export const taskedTokenRequests = <T, A extends object>(
   }
 }
 export const origin = new URL('https://api.dexscreener.com')
-export const directFetchJSON = async <T>(url: URL, signal?: AbortSignal) => {
-  return fetch(url, { signal }).then((res) => res.json() as Promise<T>)
-}
+
+/**
+ * DexScreener's edge intermittently answers with a throttle status (429/503) or an HTML
+ * challenge page under burst load. A blind `res.json()` on that HTML throws a SyntaxError
+ * that aborts an entire collection run, so a throttle status — or ANY non-JSON body — is
+ * treated as a transient failure worth retrying rather than a fatal parse error.
+ */
+const RETRYABLE_STATUS = new Set([403, 408, 425, 429, 500, 502, 503, 504])
+export const isRetryableResponse = (status: number, contentType: string | null) =>
+  RETRYABLE_STATUS.has(status) || !(contentType ?? '').toLowerCase().includes('json')
+
+export const directFetchJSON = async <T>(url: URL, signal?: AbortSignal) =>
+  retry(
+    async () => {
+      const res = await fetch(url, { signal })
+      if (isRetryableResponse(res.status, res.headers.get('content-type'))) {
+        const body = await res.text().catch(() => '')
+        throw new Error(`dexscreener ${res.status} non-JSON response for ${url.pathname}: ${body.slice(0, 120)}`)
+      }
+      return (await res.json()) as T
+    },
+    { signal, attempts: 4, delay: 3_000 },
+  )
 
 export type ChainKey = `${string}-${string}`
 export const chainKey = (chainId: string, tokenAddress: string) =>

--- a/packages/server/src/args/collect.ts
+++ b/packages/server/src/args/collect.ts
@@ -92,8 +92,9 @@ export const collect = _.memoize(() => {
  * @param providerKey The provider to check
  * @return Boolean indicating if provider content should be saved
  */
-// because pumptires is controlled by anyone, we don't want to collect it by default
-const defaultNotCollected = new Set<Collectable>(['pumptires', 'dexscreener'] as unknown as Collectable[])
+// because pumptires is controlled by anyone, we don't want to save its bytes by default
+// (link-only: a served image redirects to the source uri rather than storing untrusted content)
+const defaultNotCollected = new Set<Collectable>(['pumptires'] as unknown as Collectable[])
 
 export const checkShouldSave = _.memoize((providerKey: string) => {
   const { mode } = collect()

--- a/packages/server/src/collect/dexscreener-fetch.test.ts
+++ b/packages/server/src/collect/dexscreener-fetch.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { isRetryableResponse } from '@gibs/dexscreener'
+
+/**
+ * The collector traverses hundreds of token-pair requests per run. DexScreener's edge
+ * intermittently returns a throttle status or an HTML challenge page mid-traversal; a
+ * blind JSON.parse on that HTML used to throw and roll back the entire provider. These
+ * cases must be classified as retryable so the run self-heals instead of aborting.
+ */
+describe('isRetryableResponse', () => {
+  it('does not retry a healthy JSON response', () => {
+    expect(isRetryableResponse(200, 'application/json; charset=utf-8')).toBe(false)
+  })
+
+  it('retries an HTML challenge page served with a 200 (the observed failure)', () => {
+    expect(isRetryableResponse(200, 'text/html; charset=utf-8')).toBe(true)
+  })
+
+  it('retries when the content type is missing entirely', () => {
+    expect(isRetryableResponse(200, null)).toBe(true)
+  })
+
+  it('retries explicit throttle and gateway statuses even if labelled JSON', () => {
+    for (const status of [403, 408, 425, 429, 500, 502, 503, 504]) {
+      expect(isRetryableResponse(status, 'application/json')).toBe(true)
+    }
+  })
+
+  it('does not retry a legitimate JSON error response (avoids hammering on real 404s)', () => {
+    expect(isRetryableResponse(404, 'application/json')).toBe(false)
+  })
+})

--- a/packages/server/src/collect/dexscreener.ts
+++ b/packages/server/src/collect/dexscreener.ts
@@ -15,6 +15,7 @@ import { Collector } from '@gibs/dexscreener/collector'
 
 import { fetch } from '../fetch'
 import * as db from '../db'
+import { toCAIP2 } from '../chain-id'
 import * as utils from '../utils'
 import type { Network } from '../db/schema-types'
 import { terminalCounterTypes, terminalLogTypes, TerminalRowProxy, terminalRowTypes } from '../log/types'
@@ -208,11 +209,16 @@ class DexscreenerCollector extends BaseCollector {
           const { getDrizzle } = await import('../db/drizzle')
           const { eq: eqOp, and: andOp } = await import('drizzle-orm')
           const schemaMod = await import('../db/schema')
+          // network.chain_id stores CAIP-2 strings (eip155-369) since the April migration,
+          // so the bare numeric id never matches — convert before querying.
           const [network] = (await getDrizzle()
             .select()
             .from(schemaMod.network)
             .where(
-              andOp(eqOp(schemaMod.network.type, chain.type), eqOp(schemaMod.network.chainId, chain.id.toString())),
+              andOp(
+                eqOp(schemaMod.network.type, chain.type),
+                eqOp(schemaMod.network.chainId, toCAIP2(chain.id.toString())),
+              ),
             )
             .limit(1)) as Network[]
           const k = chain.id.toString()


### PR DESCRIPTION
Promotes the dexscreener collection fixes from staging to production.

- **Collect dexscreener metadata.** Removes dexscreener from the never-save set so its tokens are persisted (metadata only — no icon bytes yet).
- **Match dexscreener lookup to CAIP-2 ids.** The network lookup queried the bare numeric chain id, but `network.chain_id` stores CAIP-2 strings (`eip155-369`) since the April migration, so it never matched and the token loop early-returned. Now converts via `toCAIP2()` before querying.
- **Retry throttle and non-JSON responses.** DexScreener's edge intermittently returns a throttle status or an HTML challenge page under burst load; a blind `res.json()` on that HTML threw a SyntaxError that aborted the whole run. Now classifies throttle statuses and any non-JSON body as retryable.

Production impact: a collection cycle now spends roughly 13.6 minutes traversing dexscreener for metadata, where it previously early-returned instantly. Adds about 3,240 tokens of list coverage.